### PR TITLE
Refactor/#52 진행중인 면접을 찾는 도메인 인터페이스를 추가

### DIFF
--- a/src/main/java/com/mock/interview/interview/application/InterviewService.java
+++ b/src/main/java/com/mock/interview/interview/application/InterviewService.java
@@ -71,7 +71,9 @@ public class InterviewService {
                 interviewTitle, timer,
                 interviewConfig.getInterviewType(), candidateInfo, topics
         );
-        interviewStartService.start(interview, repository, users);
+
+        repository.save(interview);
+        interviewStartService.start(interview, users);
         return interview.getId();
     }
 }

--- a/src/main/java/com/mock/interview/interview/domain/ActiveInterviewFinder.java
+++ b/src/main/java/com/mock/interview/interview/domain/ActiveInterviewFinder.java
@@ -1,0 +1,9 @@
+package com.mock.interview.interview.domain;
+
+import com.mock.interview.user.domain.model.Users;
+
+import java.time.LocalDateTime;
+
+public interface ActiveInterviewFinder {
+    boolean hasActiveInterview(Users users, LocalDateTime now);
+}

--- a/src/main/java/com/mock/interview/interview/domain/InterviewStartService.java
+++ b/src/main/java/com/mock/interview/interview/domain/InterviewStartService.java
@@ -9,28 +9,19 @@ import com.mock.interview.user.domain.model.Users;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class InterviewStartService {
-    private final int CURRENT_INTERVIEW_IDX = 0;
     private final InterviewTimeHolder timeHolder;
-    public void start(Interview interview, InterviewRepository repository, Users users) {
-        List<Interview> currentInterviewList = repository.findCurrentInterview(users.getId(), RepositoryConst.LIMIT_ONE);
-        if(!currentInterviewList.isEmpty())
-            verifyCurrentInterview(currentInterviewList.get(CURRENT_INTERVIEW_IDX));
-
-        repository.save(interview);
-        interview.continueInterview(timeHolder.now());
-    }
-
-    private void verifyCurrentInterview(Interview currentInterview) {
-        if(isActive(currentInterview))
+    private final ActiveInterviewFinder activeInterviewFinder;
+    public void start(Interview interview, Users users) {
+        LocalDateTime now = timeHolder.now();
+        if(activeInterviewFinder.hasActiveInterview(users, now))
             throw new InterviewAlreadyInProgressException();
-    }
 
-    private boolean isActive(Interview currentInterview) {
-        return !currentInterview.isTimeout(timeHolder.now());
+        interview.continueInterview(now);
     }
 }

--- a/src/main/java/com/mock/interview/interview/infra/ActiveInterviewFinderImpl.java
+++ b/src/main/java/com/mock/interview/interview/infra/ActiveInterviewFinderImpl.java
@@ -1,0 +1,18 @@
+package com.mock.interview.interview.infra;
+
+import com.mock.interview.interview.domain.ActiveInterviewFinder;
+import com.mock.interview.user.domain.model.Users;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ActiveInterviewFinderImpl implements ActiveInterviewFinder {
+
+    @Override
+    public boolean hasActiveInterview(Users users, LocalDateTime now) {
+        return false;
+    }
+}

--- a/src/main/java/com/mock/interview/interview/infra/ActiveInterviewFinderImpl.java
+++ b/src/main/java/com/mock/interview/interview/infra/ActiveInterviewFinderImpl.java
@@ -2,17 +2,30 @@ package com.mock.interview.interview.infra;
 
 import com.mock.interview.interview.domain.ActiveInterviewFinder;
 import com.mock.interview.user.domain.model.Users;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 
+import static com.mock.interview.interview.domain.model.QInterview.interview;
+
 @Service
 @RequiredArgsConstructor
 public class ActiveInterviewFinderImpl implements ActiveInterviewFinder {
 
+    private final JPAQueryFactory query;
+
     @Override
     public boolean hasActiveInterview(Users users, LocalDateTime now) {
-        return false;
+        Integer exist = query.selectOne()
+                .from(interview)
+                .where(interview.candidateInfo.users.id.eq(users.getId()),
+                        interview.timer.startedAt.eq(now).or(interview.timer.startedAt.before(now)),
+                        interview.timer.expiredAt.after(now)
+                )
+                .fetchFirst();
+
+        return exist != null;
     }
 }

--- a/src/main/java/com/mock/interview/interviewconversationpair/infra/InterviewConversationRepositoryForView.java
+++ b/src/main/java/com/mock/interview/interviewconversationpair/infra/InterviewConversationRepositoryForView.java
@@ -39,7 +39,7 @@ public class InterviewConversationRepositoryForView {
     }
 
     private BooleanExpression userIdEq(long userId) {
-        return interviewConversationPair.interview.users.id.eq(userId);
+        return interviewConversationPair.interview.candidateInfo.users.id.eq(userId);
     }
 
     private BooleanExpression conversationIdEq(long conversationId) {

--- a/src/test/java/com/mock/interview/ExternalDBTest.java
+++ b/src/test/java/com/mock/interview/ExternalDBTest.java
@@ -1,0 +1,18 @@
+package com.mock.interview;
+
+import com.mock.interview.global.QueryDslConfig;
+import com.mock.interview.global.RedisConfig;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@DataJpaTest
+@Import({QueryDslConfig.class, RedisConfig.class})
+public @interface ExternalDBTest {
+}

--- a/src/test/java/com/mock/interview/interview/domain/InterviewStartServiceTest.java
+++ b/src/test/java/com/mock/interview/interview/domain/InterviewStartServiceTest.java
@@ -1,0 +1,44 @@
+package com.mock.interview.interview.domain;
+
+import com.mock.interview.interview.domain.exception.InterviewAlreadyInProgressException;
+import com.mock.interview.interview.domain.model.Interview;
+import com.mock.interview.user.domain.model.Users;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class InterviewStartServiceTest {
+    @Mock InterviewTimeHolder timeHolder;
+    @Mock ActiveInterviewFinder activeInterviewFinder;
+    @InjectMocks InterviewStartService startService;
+
+    @DisplayName("현재 이미 진행중인 면접이 있다면 면접을 진행하지 않는다.")
+    @Test
+    void test1() {
+        when(activeInterviewFinder.hasActiveInterview(any(), any())).thenReturn(true);
+
+        assertThrows(InterviewAlreadyInProgressException.class,
+                () -> startService.start(mock(Interview.class), mock(Users.class))
+        );
+    }
+
+    @DisplayName("현재 이미 진행중인 면접이 있다면 면접 진행한다.")
+    @Test
+    void test2() {
+        when(activeInterviewFinder.hasActiveInterview(any(), any())).thenReturn(false);
+
+        Interview interview = mock(Interview.class);
+        startService.start(interview, mock(Users.class));
+
+        // TODO: 행위 검증을 상태검증으로 바꿀 방법
+        //      InterviewState 같은 것을 필드로 두고 면접을 진행하면 WAIT_TO_QUESTION이 된다면?
+        verify(interview).continueInterview(any());
+    }
+}

--- a/src/test/java/com/mock/interview/interview/domain/model/TestInterviewBuilder.java
+++ b/src/test/java/com/mock/interview/interview/domain/model/TestInterviewBuilder.java
@@ -1,10 +1,13 @@
 package com.mock.interview.interview.domain.model;
 
+import com.mock.interview.category.domain.model.JobCategory;
+import com.mock.interview.category.domain.model.JobPosition;
 import com.mock.interview.experience.domain.Experience;
 import com.mock.interview.interview.TimeUtils;
 import com.mock.interview.interview.application.dto.InterviewTopicDto;
 import com.mock.interview.interview.presentation.dto.InterviewType;
 import com.mock.interview.tech.domain.model.TechnicalSubjects;
+import com.mock.interview.user.domain.model.Users;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -25,12 +28,19 @@ public class TestInterviewBuilder {
     private LocalDateTime startedAt;
     private LocalDateTime expiredAt;
     private InterviewType type;
-    private List<TechnicalSubjects> techTopics = List.of(mock(TechnicalSubjects.class));
-    private List<Experience> experiencesTopics = List.of(mock(Experience.class));
+    private List<TechnicalSubjects> techTopics;
+    private List<Experience> experiencesTopics;
+
+    private Users users;
+    private JobCategory category = mock(JobCategory.class);
+    private JobPosition position = mock(JobPosition.class);
 
     public TestInterviewBuilder() {
         interviewType(DEFAULT_INTERVIEW_TYPE);
         timer(DEFAULT_START_AT, DEFAULT_EXPIRED_AT);
+        users(mock(Users.class));
+        techTopics(List.of(mock(TechnicalSubjects.class)));
+        experienceTopics(List.of(mock(Experience.class)));
     }
 
     public TestInterviewBuilder timer(LocalDateTime startedAt, LocalDateTime expiredAt) {
@@ -45,6 +55,21 @@ public class TestInterviewBuilder {
         return this;
     }
 
+    public TestInterviewBuilder users(Users users) {
+        this.users = users;
+        return this;
+    }
+
+    public TestInterviewBuilder category(JobCategory category) {
+        this.category = category;
+        return this;
+    }
+
+    public TestInterviewBuilder position(JobPosition position) {
+        this.position = position;
+        return this;
+    }
+
     public TestInterviewBuilder techTopics(List<TechnicalSubjects> techTopics) {
         this.techTopics = techTopics;
         return this;
@@ -55,12 +80,11 @@ public class TestInterviewBuilder {
         return this;
     }
 
-
     public Interview build() {
         return Interview.create(
                 mock(InterviewTitle.class),
                 new InterviewTimer(durationMinute, startedAt, expiredAt), type,
-                mock(CandidateInfo.class),
+                new CandidateInfo(users, category, position),
                 InterviewTopicDto.builder()
                         .techTopics(techTopics)
                         .experienceTopics(experiencesTopics)

--- a/src/test/java/com/mock/interview/interview/infra/ActiveInterviewFinderImplTest.java
+++ b/src/test/java/com/mock/interview/interview/infra/ActiveInterviewFinderImplTest.java
@@ -1,0 +1,98 @@
+package com.mock.interview.interview.infra;
+
+import com.mock.interview.ExternalDBTest;
+import com.mock.interview.category.domain.model.JobCategory;
+import com.mock.interview.category.domain.model.JobPosition;
+import com.mock.interview.interview.domain.ActiveInterviewFinder;
+import com.mock.interview.interview.domain.model.Interview;
+import com.mock.interview.interview.domain.model.TestInterviewBuilder;
+import com.mock.interview.user.domain.model.Users;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.mock.interview.interview.TimeUtils.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExternalDBTest
+class ActiveInterviewFinderImplTest {
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    JPAQueryFactory query;
+
+    ActiveInterviewFinder finder;
+    private Users users;
+
+    private TestInterviewBuilder builderForPersist() {
+        JobCategory category = JobCategory.createCategory("AAA");
+        JobPosition position = JobPosition.create("BBB", category);
+        em.persist(category);
+        em.persist(position);
+        return TestInterviewBuilder.builder()
+                .category(category)
+                .position(position)
+                .techTopics(Collections.EMPTY_LIST)
+                .experienceTopics(Collections.EMPTY_LIST);
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        finder = new ActiveInterviewFinderImpl(query);
+
+        users = Users.createUser("ABC@gmail.com", "ABC", null);
+        em.persist(users);
+    }
+
+    @DisplayName("기준 시간에 활성화된 면접이 있다면 true를 반환한다.")
+    @Test
+    void test1() {
+        Interview interview = builderForPersist()
+                .timer(time(0, 0), time(0, 30))
+                .users(users)
+                .build();
+        em.persist(interview);
+        em.flush();
+        em.clear();
+
+        assertTrue(finder.hasActiveInterview(users, time(0, 20)));
+    }
+
+    @DisplayName("기준 시간에 활성화된 면접이 있다면 false를 반환한다.")
+    @Test
+    void test2() {
+        Interview interview = builderForPersist()
+                .timer(time(0, 0), time(0, 30))
+                .users(users)
+                .build();
+        em.persist(interview);
+        em.flush();
+        em.clear();
+
+        assertFalse(finder.hasActiveInterview(users, time(0, 40)));
+    }
+
+    @DisplayName("시작시간 <= 기준 < 만료시간의 범위를 갖는다.")
+    @Test
+    void test3() {
+        Interview interview = builderForPersist()
+                .timer(time(0, 0), time(0, 30))
+                .users(users)
+                .build();
+        em.persist(interview);
+        em.flush();
+        em.clear();
+
+        assertTrue(finder.hasActiveInterview(users, time(0, 0)));
+        assertFalse(finder.hasActiveInterview(users, time(0, 30)));
+    }
+
+}


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #52 

<!--
 전달할 내용
-->
## comment
- 면접 시작 서비스에서만 면접을 생성할 수 있게 만드는게 좋을까?
- 면접 시작 서비스에 행위 검증이 들어갔는데 상태 검증으로 바꾸기 위해서 InterviewStatus라는 enum타입으로 표현하고 진행시 내부 status를 바꾸는 로직을 추가할까?
